### PR TITLE
Force class data

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,15 +198,21 @@ var createPluginFactory = function(options) {
             return t.objectExpression(properties);
         }
 
-        function wrapNodeReference(loc, node, type) {
+        function wrapNodeReference(loc, node, type, force) {
+            var args = [
+                t.identifier(node.id.name),
+                createInfoObject(
+                    loc,
+                    type ? [simpleProperty('type',t.stringLiteral('class'))] : null
+                )
+            ];
+
+            if (force) {
+                args.push(t.booleanLiteral(true));
+            }
+
             return t.expressionStatement(
-                createRegistratorCall([
-                    t.identifier(node.id.name),
-                    createInfoObject(
-                        loc,
-                        type ? [simpleProperty('type',t.stringLiteral('class'))] : null
-                    )
-                ])
+                createRegistratorCall(args)
             );
         }
 
@@ -402,7 +408,7 @@ var createPluginFactory = function(options) {
                         insertPath = path.parentPath;
                     }
 
-                    insertPath.insertAfter(wrapNodeReference(loc, node, 'class'));
+                    insertPath.insertAfter(wrapNodeReference(loc, node, 'class', true));
                 },
 
                 'FunctionExpression|ArrowFunctionExpression|ClassExpression|ArrayExpression|JSXElement': {

--- a/spec/fixtures/ClassDeclaration/expected.js
+++ b/spec/fixtures/ClassDeclaration/expected.js
@@ -20,7 +20,7 @@ var Foo = (testWrapper)(function Foo() {
 (testWrapper)(Foo, {
     loc: "{{path}}:1:1:5:2",
     type: "class"
-});
+}, true);
 
 var Foo2 = function (_Foo) {
     _inherits(Foo2, _Foo);
@@ -40,7 +40,7 @@ var Foo2 = function (_Foo) {
 (testWrapper)(Foo2, {
     loc: "{{path}}:7:1:11:2",
     type: "class"
-});
+}, true);
 var Bar = exports.Bar = (testWrapper)(function Bar() {
     _classCallCheck(this, Bar);
 
@@ -51,7 +51,7 @@ var Bar = exports.Bar = (testWrapper)(function Bar() {
 (testWrapper)(Bar, {
     loc: "{{path}}:13:8:17:2",
     type: "class"
-});
+}, true);
 
 var Bar2 = exports.Bar2 = function (_Bar) {
     _inherits(Bar2, _Bar);
@@ -71,4 +71,4 @@ var Bar2 = exports.Bar2 = function (_Bar) {
 (testWrapper)(Bar2, {
     loc: "{{path}}:19:8:23:2",
     type: "class"
-});
+}, true);

--- a/spec/fixtures/React/expected.js
+++ b/spec/fixtures/React/expected.js
@@ -32,7 +32,7 @@ var Bar2 = function (_Bar) {
 (testWrapper)(Bar2, {
   loc: '{{path}}:1:1:5:2',
   type: 'class'
-});
+}, true);
 
 
 var Bar = (testWrapper)({


### PR DESCRIPTION
Information about a constructor overrides information about a class, see https://github.com/restrry/babel-plugin-source-wrapper/blob/master/spec/fixtures/ClassDeclaration/expected.js#L56-L74

```js
var Bar2 = exports.Bar2 = function (_Bar) {
    _inherits(Bar2, _Bar);

    function Bar2() {
        _classCallCheck(this, Bar2);

        return _possibleConstructorReturn(this, (Bar2.__proto__ || Object.getPrototypeOf(Bar2)).call(this));
    }

    // First occurrence of location, incorrect
    (testWrapper)(Bar2, {
        loc: "{{path}}:20:5:22:6"
    });
    return Bar2;
}(Bar);

// Second occurrence of location, correct but ignored
(testWrapper)(Bar2, {
    loc: "{{path}}:19:8:23:2",
    type: "class"
});
```

I've added third argument to force usage of class information.